### PR TITLE
Update config.js - Suppression de Google Analytics

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -116,12 +116,6 @@ module.exports = {
         // publishedAt: $page => $page.frontmatter.date && new Date($page.frontmatter.date),
         // modifiedAt: $page => $page.lastUpdated && new Date($page.lastUpdated),
       }
-    ],
-    [
-      '@vuepress/google-analytics',
-      {
-        'ga': 'UA-122478510-1' // UA-00000000-0
-      }
     ]
   ],
   dest: 'build',


### PR DESCRIPTION
Suppression du Google Analytics pour cette version portable afin d'éviter tout remontée d'info à Google via ce plugin, l'utilisateur ne pouvant pas ajouter d'ad-blocker sur cette version electron.